### PR TITLE
fix: Add instance label to selector labels

### DIFF
--- a/charts/hermes-relayer/Chart.yaml
+++ b/charts/hermes-relayer/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: hermes-relayer
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: 1.5.1

--- a/charts/hermes-relayer/templates/_helpers.tpl
+++ b/charts/hermes-relayer/templates/_helpers.tpl
@@ -55,6 +55,7 @@ Selector labels
 */}}
 {{- define "hermes-relayer.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "hermes-relayer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Default value for label `app.kubernetes.io/name` in hermes-relayer chart is `hermes-relayer` which is not unique enough for hermes service selector if there are other hermes-relayer chart instances installed on the same namepsace hence additional selector label added with this PR.