### PR TITLE
feat: Add support for providing env vars for relayer-exporter chart

### DIFF
--- a/charts/relayer-exporter/Chart.yaml
+++ b/charts/relayer-exporter/Chart.yaml
@@ -4,4 +4,4 @@ name: relayer-exporter
 description: A Helm chart for relayer_exporter
 type: application
 version: 0.1.0
-appVersion: 0.4.0
+appVersion: 0.5.0

--- a/charts/relayer-exporter/Chart.yaml
+++ b/charts/relayer-exporter/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: relayer-exporter
 description: A Helm chart for relayer_exporter
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: 0.5.0

--- a/charts/relayer-exporter/templates/_helpers.tpl
+++ b/charts/relayer-exporter/templates/_helpers.tpl
@@ -60,3 +60,33 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Given a dictionary of variable=value pairs, render a container env block.
+Environment variables are sorted alphabetically
+*/}}
+{{- define "relayer-exporter.renderEnv" -}}
+
+{{- $dict := . -}}
+
+{{- range keys . | sortAlpha }}
+{{- $val := pluck . $dict | first -}}
+{{- $valueType := printf "%T" $val -}}
+{{ if eq $valueType "map[string]interface {}" }}
+- name: {{ . }}
+{{ toYaml $val | indent 2 -}}
+{{- else if eq $valueType "string" }}
+{{- if regexMatch "valueFrom" $val }}
+- name: {{ . }}
+{{ $val | indent 2 }}
+{{- else }}
+- name: {{ . }}
+  value: {{ $val | quote }}
+{{- end }}
+{{- else }}
+- name: {{ . }}
+  value: {{ $val | quote }}
+{{- end }}
+{{- end -}}
+
+{{- end -}}

--- a/charts/relayer-exporter/templates/deployment.yaml
+++ b/charts/relayer-exporter/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
             - --config
             - /config/config.yaml
             - --log-level={{ .Values.logLevel }}
+          env:
+            {{- include "relayer-exporter.renderEnv" .Values.env | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/relayer-exporter/values.yaml
+++ b/charts/relayer-exporter/values.yaml
@@ -27,6 +27,13 @@ service:
   type: ClusterIP
   port: 8008
 
+# env:
+#   GITHUB_TOKEN:
+#     valueFrom:
+#       secretKeyRef:
+#         key: token
+#         name: github-token
+
 resources: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
Allows to specify env vars for a container with relayer_exporter. 
Useful for providing GITHUB_TOKEN env var needed for a feature introduced in https://github.com/archway-network/relayer_exporter/pull/10