### PR TITLE
fix: Correct templates for service monitor

### DIFF
--- a/charts/chainpulse/Chart.yaml
+++ b/charts/chainpulse/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: chainpulse
 description: A Helm chart for chainpulse
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.3.2

--- a/charts/chainpulse/templates/serviceMonitor.yaml
+++ b/charts/chainpulse/templates/serviceMonitor.yaml
@@ -26,12 +26,10 @@ spec:
       scrapeTimeout: {{ . }}
       {{- end }}
       {{- if .Values.serviceMonitor.metricRelabelings }}
-      metricRelabelings:
-      {{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+      metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
       {{- end }}
       {{- if .Values.serviceMonitor.relabelings }}
-      relabelings:
-      {{ toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+      relabelings: {{ toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
   {{- if .Values.serviceMonitor.targetLabels }}
   targetLabels:

--- a/charts/hermes-relayer/Chart.yaml
+++ b/charts/hermes-relayer/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: hermes-relayer
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.2
+version: 1.3.3
 appVersion: 1.6.0

--- a/charts/hermes-relayer/templates/serviceMonitor.yaml
+++ b/charts/hermes-relayer/templates/serviceMonitor.yaml
@@ -27,12 +27,10 @@ spec:
       scrapeTimeout: {{ . }}
       {{- end }}
       {{- if .Values.serviceMonitor.metricRelabelings }}
-      metricRelabelings:
-      {{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+      metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
       {{- end }}
       {{- if .Values.serviceMonitor.relabelings }}
-      relabelings:
-      {{ toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+      relabelings: {{ toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
   {{- if .Values.serviceMonitor.targetLabels }}
   targetLabels:

--- a/charts/relayer-exporter/Chart.yaml
+++ b/charts/relayer-exporter/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: relayer-exporter
 description: A Helm chart for relayer_exporter
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.6.0

--- a/charts/relayer-exporter/templates/serviceMonitor.yaml
+++ b/charts/relayer-exporter/templates/serviceMonitor.yaml
@@ -26,12 +26,10 @@ spec:
       scrapeTimeout: {{ . }}
       {{- end }}
       {{- if .Values.serviceMonitor.metricRelabelings }}
-      metricRelabelings:
-      {{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+      metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
       {{- end }}
       {{- if .Values.serviceMonitor.relabelings }}
-      relabelings:
-      {{ toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+      relabelings: {{ toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
   {{- if .Values.serviceMonitor.targetLabels }}
   targetLabels:


### PR DESCRIPTION
PR fixes `serviceMonitor.yaml` to have it properly rendered when there are `metricRelabelings` or `relabelings` provided.