### PR TITLE
feat: Use separate path for testnets IBC paths

### DIFF
--- a/charts/relayer-exporter/Chart.yaml
+++ b/charts/relayer-exporter/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: relayer-exporter
 description: A Helm chart for relayer_exporter
 type: application
-version: 0.2.3
-appVersion: 0.6.0
+version: 0.3.0
+appVersion: 0.8.0

--- a/charts/relayer-exporter/values.yaml
+++ b/charts/relayer-exporter/values.yaml
@@ -59,3 +59,4 @@ config:
     org: archway-network
     repo: networks
     dir: _IBC
+    testnetsDir: testnets/_IBC


### PR DESCRIPTION
Adds default config for testnets IBC paths, based on https://github.com/archway-network/relayer_exporter/pull/19