### PR TITLE
feat: Update relayer_exporter to v0.12.0

### DIFF
--- a/charts/relayer-exporter/Chart.yaml
+++ b/charts/relayer-exporter/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: relayer-exporter
 description: A Helm chart for relayer_exporter
 type: application
-version: 0.6.0
-appVersion: 0.11.0
+version: 0.7.0
+appVersion: 0.12.0


### PR DESCRIPTION
Update relayer-exporter chart to use https://github.com/archway-network/relayer_exporter/releases/tag/v0.12.0