### PR TITLE
feat: add backoffLimit to clientUpdateCronjob

### DIFF
--- a/charts/hermes-relayer/templates/clientUpdateCronJob.yaml
+++ b/charts/hermes-relayer/templates/clientUpdateCronJob.yaml
@@ -10,6 +10,7 @@ spec:
     metadata:
       name: {{ include "hermes-relayer.fullname" . }}-job
     spec:
+      backoffLimit: {{ .Values.retryAmount }}
       template:
         metadata:
         {{- with .Values.cronjobAnnotations }}

--- a/charts/hermes-relayer/templates/clientUpdateCronJob.yaml
+++ b/charts/hermes-relayer/templates/clientUpdateCronJob.yaml
@@ -10,7 +10,7 @@ spec:
     metadata:
       name: {{ include "hermes-relayer.fullname" . }}-job
     spec:
-      backoffLimit: {{ .Values.retryAmount }}
+      backoffLimit: {{ .Values.backoffLimit }}
       template:
         metadata:
         {{- with .Values.cronjobAnnotations }}

--- a/charts/hermes-relayer/values.yaml
+++ b/charts/hermes-relayer/values.yaml
@@ -31,7 +31,7 @@ cronjobAnnotations: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
-retryAmount: 3
+backoffLimit: 6
 service:
   telemetryPort: 3001
 serviceMonitor:

--- a/charts/hermes-relayer/values.yaml
+++ b/charts/hermes-relayer/values.yaml
@@ -7,7 +7,8 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-resources: {}
+resources:
+  {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -30,6 +31,7 @@ cronjobAnnotations: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+retryAmount: 3
 service:
   telemetryPort: 3001
 serviceMonitor:


### PR DESCRIPTION
This adds possibility to configure the backoffLimit of the update cronjob.
The idea is that we can increase this to the amount to not have a faulty update.