### PR TITLE
feat: Release latest validator-exporter chart

### DIFF
--- a/charts/validator-exporter/Chart.yaml
+++ b/charts/validator-exporter/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: validator-exporter
 description: A Helm chart for validator-exporter
 type: application
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.1.0
+appVersion: 1.1.0


### PR DESCRIPTION
Defaults to the latest validator-exporter containing https://github.com/archway-network/validator-exporter/pull/3